### PR TITLE
Makes the plugin an independent one from sbt-catalysts Plugin

### DIFF
--- a/.scalafmt
+++ b/.scalafmt
@@ -1,2 +1,0 @@
-style = defaultWithAlign
-maxColumn = 100

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Settings ready to be used in your project:
 
 * `pgpSettings`: https://goo.gl/OmcBfs, useful to deploy to Sonatype.
 * `testScriptedSettings`: https://goo.gl/ciLZL4, some basic configuration settings to test your sbt plugins.
-* `miscSettings`: https://goo.gl/bxp4EF, to enjoy with a fancy sbt shell promopt.
+* `miscSettings`: https://goo.gl/bxp4EF, to enjoy with a fancy sbt shell prompt.
 
 ## Extra-Tasks
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 # sbt-catalysts-extras
 
-**sbt-catalysts-extras** is an SBT plugin that extends the [sbt-catalyst](https://github.com/typelevel/sbt-catalysts) plugin, providing more dependencies and settings outside from Typelevel org.
+**sbt-catalysts-extras** is an SBT plugin, which forks and extends the [sbt-catalyst](https://github.com/typelevel/sbt-catalysts) plugin, providing more dependencies and settings outside from Typelevel org.
 
 ## Installation
 
 Add the following line to `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("com.fortysevendeg" % "sbt-catalysts-extras" % "0.0.3")
+addSbtPlugin("com.fortysevendeg" % "sbt-catalysts-extras" % "0.1.0")
 ```
 
 See some examples about how to use it in the [Typelevel sbt-catalyst](https://github.com/typelevel/sbt-catalysts#quick-example).
@@ -28,7 +28,7 @@ Settings ready to be used in your project:
 
 * `pgpSettings`: https://goo.gl/OmcBfs, useful to deploy to Sonatype.
 * `testScriptedSettings`: https://goo.gl/ciLZL4, some basic configuration settings to test your sbt plugins.
-* `miscSettings`: https://goo.gl/bxp4EF, to enjoy with a fancy sbt shell.
+* `miscSettings`: https://goo.gl/bxp4EF, to enjoy with a fancy sbt shell promopt.
 
 ## Extra-Tasks
 

--- a/build.sbt
+++ b/build.sbt
@@ -19,16 +19,24 @@ lazy val artifactSettings = Seq(
 
 lazy val pluginSettings = Seq(
   sbtPlugin := true,
-  scalaVersion in ThisBuild := "2.10.6",
   resolvers ++= Seq(sonatypeRepo("snapshots"), sonatypeRepo("releases")),
-  // Extension import:
-  addSbtPlugin("org.typelevel" % "sbt-catalysts" % "0.1.12"),
-  // Additional Plugins:
-  addSbtPlugin("de.heikoseeberger" % "sbt-header"    % "1.6.0"),
-  addSbtPlugin("com.eed3si9n"      % "sbt-buildinfo" % "0.6.1"),
-  libraryDependencies <+= (sbtVersion) { sv =>
-    "org.scala-sbt" % "scripted-plugin" % sv
-  }
+  addSbtPlugin("com.eed3si9n"        % "sbt-unidoc"             % "0.3.3"),
+  addSbtPlugin("com.github.gseitz"   % "sbt-release"            % "1.0.3"),
+  addSbtPlugin("com.github.tkawachi" % "sbt-doctest"            % "0.4.1"),
+  addSbtPlugin("org.xerial.sbt"      % "sbt-sonatype"           % "1.1"),
+  addSbtPlugin("com.jsuereth"        % "sbt-pgp"                % "1.0.1"),
+  addSbtPlugin("com.typesafe.sbt"    % "sbt-ghpages"            % "0.5.4"),
+  addSbtPlugin("com.typesafe.sbt"    % "sbt-site"               % "1.1.0"),
+  addSbtPlugin("org.tpolecat"        % "tut-plugin"             % "0.4.6"),
+  addSbtPlugin("pl.project13.scala"  % "sbt-jmh"                % "0.2.16"),
+  addSbtPlugin("org.scalastyle"      %% "scalastyle-sbt-plugin" % "0.8.0"),
+  addSbtPlugin("org.scoverage"       % "sbt-scoverage"          % "1.5.0"),
+  addSbtPlugin("com.typesafe.sbt"    % "sbt-git"                % "0.8.5"),
+  addSbtPlugin("org.scala-js"        % "sbt-scalajs"            % "0.6.13"),
+  addSbtPlugin("com.fortysevendeg"   % "sbt-microsites"         % "0.3.2"),
+  addSbtPlugin("de.heikoseeberger"   % "sbt-header"             % "1.6.0"),
+  addSbtPlugin("com.eed3si9n"        % "sbt-buildinfo"          % "0.6.1"),
+  libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
 )
 
 lazy val gpgFolder = sys.env.getOrElse("PGP_FOLDER", ".")
@@ -49,14 +57,12 @@ lazy val miscSettings = Seq(
     val projectName = Project.extract(s).currentProject.id
 
     s"$blue$projectName$white>${c.RESET}"
-  },
-  scalafmtConfig in ThisBuild := Some(file(".scalafmt"))
+  }
 )
 
 lazy val allSettings = artifactSettings ++
     pluginSettings ++
     miscSettings ++
-    reformatOnCompileSettings ++
     sharedReleaseProcess ++
     pgpSettings ++
     credentialSettings ++

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.12
+sbt.version = 0.13.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,4 @@
 addSbtPlugin("de.heikoseeberger" % "sbt-header"    % "1.6.0")
 addSbtPlugin("org.typelevel"     % "sbt-catalysts" % "0.1.12")
-addSbtPlugin("com.geirsson"      % "sbt-scalafmt"  % "0.4.7")
 
-libraryDependencies <+= sbtVersion("org.scala-sbt" % "scripted-plugin" % _)
+libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value

--- a/src/main/scala/catext/CatExtKeys.scala
+++ b/src/main/scala/catext/CatExtKeys.scala
@@ -16,7 +16,6 @@
 
 package catext
 
-import sbtcatalysts._
 import sbt._
 
 trait CatExtKeys {

--- a/src/main/scala/catext/CatExtPlugin.scala
+++ b/src/main/scala/catext/CatExtPlugin.scala
@@ -19,9 +19,11 @@ package catext
 import sbt.Keys._
 import sbt._
 import ScriptedPlugin._
+
 import scala.collection.immutable.ListMap
 import complete.DefaultParsers._
 import com.typesafe.sbt.pgp.PgpKeys._
+import sbtcatalysts.CatalystsBase
 
 object CatExtPlugin extends AutoPlugin {
 
@@ -36,7 +38,7 @@ object CatExtPlugin extends AutoPlugin {
   override def projectSettings: Seq[Def.Setting[_]] = tasksSettings
 }
 
-trait CatExtSettings {
+trait CatExtSettings extends CatalystsBase {
 
   def guard[T](flag: Boolean)(res: Seq[T]): Seq[T] = if (flag) res else Seq.empty
 
@@ -51,7 +53,7 @@ trait CatExtSettings {
 
   lazy val testScriptedSettings =
     ScriptedPlugin.scriptedSettings ++ Seq(
-      scriptedDependencies <<= (compile in Test) map { (analysis) =>
+      scriptedDependencies := (compile in Test) map { (analysis) =>
         Unit
       },
       scriptedLaunchOpts := {

--- a/src/main/scala/catext/Dependencies.scala
+++ b/src/main/scala/catext/Dependencies.scala
@@ -17,55 +17,58 @@
 package catext
 
 import sbt._
-import sbtcatalysts.CatalystsPlugin.autoImport._
+import catext.CatExtPlugin.autoImport._
 
 object Dependencies {
 
-  import org.typelevel.Dependencies.{
-    libraries => tllibraries,
-    scalacPlugins => tlscalacPlugins,
-    macroCompatSettings => tlmacroCompatSettings
-  }
-
-  // Versions is being instantiated to have the control. It's based on
-  // https://github.com/typelevel/sbt-catalysts/blob/master/src/main/scala/org/typelevel/TypelevelDeps.scala#L15:
+  /**
+    * Versions is being instantiated to have the control.
+    * Original forked SBT Plugin: https://github.com/typelevel/sbt-catalysts/blob/69d8bb150ac6b3d79721d26c07326398ef5aae94/src/main/scala/org/typelevel/TypelevelDeps.scala
+    */
   val versions = Map[String, String](
     "algebra"             -> "0.5.1",
     "alleycats"           -> "0.1.7",
+    "aws-sdk"             -> "1.11.53",
     "catalysts"           -> "0.1.0",
-    "cats"                -> "0.7.2",
-    "circe"               -> "0.5.4",
+    "cats"                -> "0.8.1",
+    "circe"               -> "0.6.0",
     "config"              -> "1.3.0",
     "coursier"            -> "1.0.0-M14-2",
     "discipline"          -> "0.5",
-    "doobie"              -> "0.3.0",
+    "doobie"              -> "0.3.1-M2",
     "evaluator"           -> "0.1.1-SNAPSHOT",
     "export-hook"         -> "1.1.0",
-    "kind-projector"      -> "0.9.0",
-    "github4s"            -> "0.8.0-SNAPSHOT",
+    "fetch"               -> "0.4.0",
+    "github4s"            -> "0.9.0",
     "http4s"              -> "0.14.10a",
+    "kind-projector"      -> "0.9.3",
     "log4s"               -> "1.3.0",
     "machinist"           -> "0.4.1",
     "macro-compat"        -> "1.1.1",
-    "monix"               -> "2.0.3",
-    "monocle"             -> "1.2.0",
+    "monix"               -> "2.1.0",
+    "monocle"             -> "1.3.2",
     "newrelic"            -> "3.29.0",
     "paradise"            -> "2.1.0",
+    "pure-config"         -> "0.3.3",
     "refined"             -> "0.3.6",
-    "roshttp"             -> "1.1.0",
+    "roshttp"             -> "2.0.0-RC1",
+    "scala-exercises"     -> "0.3.0-SNAPSHOT",
+    "scala-reflect"       -> "2.11.8",
+    "scalac_2.10"         -> "2.10.6",
+    "scalac_2.11"         -> "2.11.8",
+    "scalac_2.12"         -> "2.12.0",
+    "scalac"              -> "2.11.8",
     "scalacheck"          -> "1.12.5",
     "scalacheckshapeless" -> "0.3.1",
-    "scalac"              -> "2.11.8",
-    "scalac_2.11"         -> "2.11.8",
-    "scalac_2.10"         -> "2.10.6",
-    "scala-exercises"     -> "0.3.0-SNAPSHOT",
-    "scalatest"           -> "2.2.6",
+    "scalaj"              -> "2.3.0",
+    "scalatest"           -> "3.0.0",
     "scalaz"              -> "7.2.4",
     "scalazspecs2"        -> "0.4.0",
-    "shapeless"           -> "2.3.0",
-    "simulacrum"          -> "0.8.0",
+    "scanamo"             -> "0.8.1",
+    "shapeless"           -> "2.3.2",
+    "simulacrum"          -> "0.10.0",
     "slf4j"               -> "1.7.21",
-    "specs2"              -> "3.6.4"
+    "specs2"              -> "3.8.6"
   )
 
   /**
@@ -73,40 +76,103 @@ object Dependencies {
     *
     *  Library name -> version key, org, library
     */
-  val libraries = tllibraries ++ Map[String, (String, String, String)](
-      "circe-core"                  -> ("circe", "io.circe", "circe-core"),
-      "circe-generic"               -> ("circe", "io.circe", "circe-generic"),
-      "circe-parser"                -> ("circe", "io.circe", "circe-parser"),
-      "config"                      -> ("config", "com.typesafe", "config"),
-      "coursier"                    -> ("coursier", "io.get-coursier", "coursier"),
-      "coursier-cache"              -> ("coursier", "io.get-coursier", "coursier-cache"),
-      "doobie"                      -> ("doobie", "org.tpolecat", "doobie-core"),
-      "doobie-hikari"               -> ("doobie", "org.tpolecat", "doobie-contrib-hikari"),
-      "doobie-postgresql"           -> ("doobie", "org.tpolecat", "doobie-contrib-postgresql"),
-      "doobie-specs2"               -> ("doobie", "org.tpolecat", "doobie-contrib-specs2"),
-      "evaluator-client"            -> ("scala-exercises", "org.scala-exercises", "evaluator-client"),
-      "evaluator-shared"            -> ("scala-exercises", "org.scala-exercises", "evaluator-shared"),
-      "github4s"                    -> ("github4s", "com.fortysevendeg", "github4s"),
-      "http4s-dsl"                  -> ("http4s", "org.http4s", "http4s-dsl"),
-      "http4s-blaze-server"         -> ("http4s", "org.http4s", "http4s-blaze-server"),
-      "http4s-blaze-client"         -> ("http4s", "org.http4s", "http4s-blaze-client"),
-      "http4s-client"               -> ("http4s", "org.http4s", "http4s-circe"),
-      "log4s"                       -> ("log4s", "org.log4s", "log4s"),
-      "monix"                       -> ("monix", "io.monix", "monix"),
-      "newrelic"                    -> ("newrelic", "com.newrelic.agent.java", "newrelic-agent"),
-      "roshttp"                     -> ("roshttp", "fr.hmil", "roshttp"),
-      "scalacheckshapeless"         -> ("scalacheckshapeless", "com.github.alexarchambault", "scalacheck-shapeless_1.12"),
-      "scalaz-concurrent"           -> ("scalaz", "org.scalaz", "scalaz-concurrent"),
-      "scalazspecs2"                -> ("scalazspecs2", "org.typelevel", "scalaz-specs2"),
-      "scala-exercises-compiler"    -> ("scala-exercises", "org.scala-exercises", "exercise-compiler"),
-      "scala-exercises-definitions" -> ("scala-exercises", "org.scala-exercises", "definitions"),
-      "scala-exercises-runtime"     -> ("scala-exercises", "org.scala-exercises", "runtime"),
-      "slf4j-nop"                   -> ("slf4j", "org.slf4j", "slf4j-nop"),
-      "slf4j-simple"                -> ("slf4j", "org.slf4j", "slf4j-simple")
-    )
+  val libraries = Map[String, (String, String, String)](
+    "algebra-laws"                -> ("algebra", "org.typelevel", "algebra-laws"),
+    "algebra"                     -> ("algebra", "org.typelevel", "algebra"),
+    "alleycats"                   -> ("alleycats", "org.typelevel", "alleycats"),
+    "aws-sdk"                     -> ("aws-sdk", "com.amazonaws", "aws-java-sdk"),
+    "catalysts-checklite"         -> ("catalysts", "org.typelevel", "catalysts-checklite"),
+    "catalysts-lawkit"            -> ("catalysts", "org.typelevel", "catalysts-lawkit"),
+    "catalysts-macros"            -> ("catalysts", "org.typelevel", "catalysts-macros"),
+    "catalysts-platform"          -> ("catalysts", "org.typelevel", "catalysts-platform"),
+    "catalysts-scalatest"         -> ("catalysts", "org.typelevel", "catalysts-scalatest"),
+    "catalysts-specbase"          -> ("catalysts", "org.typelevel", "catalysts-specbase"),
+    "catalysts-speclite"          -> ("catalysts", "org.typelevel", "catalysts-speclite"),
+    "catalysts-specs2"            -> ("catalysts", "org.typelevel", "catalysts-specs2"),
+    "catalysts-testkit"           -> ("catalysts", "org.typelevel", "catalysts-testkit"),
+    "catalysts"                   -> ("catalysts", "org.typelevel", "catalysts"),
+    "cats-core"                   -> ("cats", "org.typelevel", "cats-core"),
+    "cats-free"                   -> ("cats", "org.typelevel", "cats-free"),
+    "cats-kernel"                 -> ("cats", "org.typelevel", "cats-kernel"),
+    "cats-laws"                   -> ("cats", "org.typelevel", "cats-laws"),
+    "cats-macros"                 -> ("cats", "org.typelevel", "cats-macros"),
+    "cats-state"                  -> ("cats", "org.typelevel", "cats-state"),
+    "cats"                        -> ("cats", "org.typelevel", "cats"),
+    "circe-core"                  -> ("circe", "io.circe", "circe-core"),
+    "circe-generic"               -> ("circe", "io.circe", "circe-generic"),
+    "circe-parser"                -> ("circe", "io.circe", "circe-parser"),
+    "config"                      -> ("config", "com.typesafe", "config"),
+    "coursier-cache"              -> ("coursier", "io.get-coursier", "coursier-cache"),
+    "coursier"                    -> ("coursier", "io.get-coursier", "coursier"),
+    "discipline"                  -> ("discipline", "org.typelevel", "discipline"),
+    "doobie-hikari"               -> ("doobie", "org.tpolecat", "doobie-contrib-hikari"),
+    "doobie-postgresql"           -> ("doobie", "org.tpolecat", "doobie-contrib-postgresql"),
+    "doobie-specs2"               -> ("doobie", "org.tpolecat", "doobie-contrib-specs2"),
+    "doobie"                      -> ("doobie", "org.tpolecat", "doobie-core"),
+    "evaluator-client"            -> ("scala-exercises", "org.scala-exercises", "evaluator-client"),
+    "evaluator-shared"            -> ("scala-exercises", "org.scala-exercises", "evaluator-shared"),
+    "export-hook"                 -> ("export-hook", "org.typelevel", "export-hook"),
+    "fetch"                       -> ("fetch", "com.fortysevendeg", "fetch"),
+    "github4s"                    -> ("github4s", "com.fortysevendeg", "github4s"),
+    "http4s-blaze-client"         -> ("http4s", "org.http4s", "http4s-blaze-client"),
+    "http4s-blaze-server"         -> ("http4s", "org.http4s", "http4s-blaze-server"),
+    "http4s-client"               -> ("http4s", "org.http4s", "http4s-circe"),
+    "http4s-dsl"                  -> ("http4s", "org.http4s", "http4s-dsl"),
+    "log4s"                       -> ("log4s", "org.log4s", "log4s"),
+    "machinist"                   -> ("machinist", "org.typelevel", "machinist"),
+    "macro-compat"                -> ("macro-compat", "org.typelevel", "macro-compat"),
+    "monix"                       -> ("monix", "io.monix", "monix"),
+    "monocle-core"                -> ("monocle", "com.github.julien-truffaut", "monocle-core"),
+    "monocle-generic"             -> ("monocle", "com.github.julien-truffaut", "monocle-generic"),
+    "monocle-law"                 -> ("monocle", "com.github.julien-truffaut", "monocle-law"),
+    "monocle-macro"               -> ("monocle", "com.github.julien-truffaut", "monocle-macro"),
+    "monocle-state"               -> ("monocle", "com.github.julien-truffaut", "monocle-state"),
+    "newrelic"                    -> ("newrelic", "com.newrelic.agent.java", "newrelic-agent"),
+    "pure-config"                 -> ("pure-config", "com.github.melrief", "pureconfig"),
+    "refined-scalacheck"          -> ("refined", "eu.timepit", "refined-scalacheck"),
+    "refined-scalaz"              -> ("refined", "eu.timepit", "refined-scalaz"),
+    "refined-scodec"              -> ("refined", "eu.timepit", "refined-scodec"),
+    "refined"                     -> ("refined", "eu.timepit", "refined"),
+    "roshttp"                     -> ("roshttp", "fr.hmil", "roshttp"),
+    "scala-exercises-compiler"    -> ("scala-exercises", "org.scala-exercises", "exercise-compiler"),
+    "scala-exercises-definitions" -> ("scala-exercises", "org.scala-exercises", "definitions"),
+    "scala-exercises-runtime"     -> ("scala-exercises", "org.scala-exercises", "runtime"),
+    "scala-reflect"               -> ("scala-reflect", "org.scala-lang", "scala-reflect"),
+    "scalacheck"                  -> ("scalacheck", "org.scalacheck", "scalacheck"),
+    "scalacheckshapeless"         -> ("scalacheckshapeless", "com.github.alexarchambault", "scalacheck-shapeless_1.12"),
+    "scalaj"                      -> ("scalaj", "org.scalaj", "scalaj-http"),
+    "scalatest"                   -> ("scalatest", "org.scalatest", "scalatest"),
+    "scalaz-concurrent"           -> ("scalaz", "org.scalaz", "scalaz-concurrent"),
+    "scalazspecs2"                -> ("scalazspecs2", "org.typelevel", "scalaz-specs2"),
+    "scanamo"                     -> ("scanamo", "com.gu", "scanamo"),
+    "shapeless"                   -> ("shapeless", "com.chuusai", "shapeless"),
+    "simulacrum"                  -> ("simulacrum", "com.github.mpilquist", "simulacrum"),
+    "slf4j-nop"                   -> ("slf4j", "org.slf4j", "slf4j-nop"),
+    "slf4j-simple"                -> ("slf4j", "org.slf4j", "slf4j-simple"),
+    "specs2-core"                 -> ("specs2", "org.specs2", "specs2-core"),
+    "specs2-scalacheck"           -> ("specs2", "org.specs2", "specs2-scalacheck")
+  )
 
-  val scalacPlugins = tlscalacPlugins
+  /**
+    * Compiler plugins definitions and links to their versions
+    *
+    * Note that one version may apply to more than one plugin.
+    *
+    * Format: Library name -> version key, org, librar, crossVersion
+    */
+  val scalacPlugins = Map[String, (String, String, String, CrossVersion)](
+    "kind-projector" -> ("kind-projector", "org.spire-math", "kind-projector", CrossVersion.binary),
+    "paradise"       -> ("paradise", "org.scalamacros", "paradise", CrossVersion.full)
+  )
 
-  def macroCompatSettings(v: Versions): Seq[Setting[_]] = tlmacroCompatSettings(v)
-
+  // Some helper methods to combine libraries
+  /**
+    * Sets all settings required for the macro-compat library.
+    *
+    * @param v Versions map to use
+    * @return All settings required for the macro-compat library
+    */
+  def macroCompatSettings(v: Versions): Seq[Setting[_]] =
+    addCompileLibs(v, "macro-compat") ++ addCompilerPlugins(v, "paradise") ++
+      scalaMacroDependencies(v)
 }

--- a/src/main/scala/sbtcatalysts/CatalystsBase.scala
+++ b/src/main/scala/sbtcatalysts/CatalystsBase.scala
@@ -1,0 +1,543 @@
+/*
+ * Copyright 2016 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sbtcatalysts
+
+import sbt._
+import Keys._
+
+import com.typesafe.sbt.pgp.PgpKeys
+import com.typesafe.sbt.pgp.PgpKeys.publishSigned
+import com.typesafe.sbt.SbtSite.SiteKeys._
+import com.typesafe.sbt.site.SitePlugin.autoImport._
+import com.typesafe.sbt.SbtGit._
+
+import com.typesafe.sbt.SbtGhPages.GhPagesKeys._
+import com.typesafe.sbt.SbtGhPages.ghpages
+
+import tut.Plugin._
+import pl.project13.scala.sbt.SbtJmh._
+import sbtunidoc.Plugin.UnidocKeys._
+import sbtunidoc.Plugin._
+import sbtrelease.ReleasePlugin.autoImport._
+import ReleaseTransformations._
+import org.scalajs.sbtplugin.ScalaJSPlugin
+import ScalaJSPlugin.autoImport._
+import scoverage.ScoverageKeys
+import org.scalajs.sbtplugin.cross.{CrossProject, CrossType}
+
+/**
+  * Original forked SBT Plugin: https://github.com/typelevel/sbt-catalysts/blob/69d8bb150ac6b3d79721d26c07326398ef5aae94/src/main/scala/sbtcatalysts/CatalystsPlugin.scala
+  *
+  * Plugin that automatically brings into scope all predefined val's and method
+  * definitions.
+  *
+  * It is very important to realise that using the plugin does not actually change the
+  * the build in any way, but merely provides the methods to help create a build.sbt.
+  *
+  * Compared to a plugin that "does everything", the advantage of this approach is that it is far
+  * easier to use other functionality where appropriate and also to "see" what the build is
+  * is actually doing, as the methods are (mainly) just pure SBT methods.
+  *
+  * Where we do deviate from "pure" SBT is how we define library dependencies. The norm would be:
+  *
+  * In a small project, define the library dependencies explicitly:
+  *
+  *    libraryDependencies += "org.typelevel" %% "alleycats" %  "0.1.0"
+  *
+  * If another sub-project also has this dependency, it's common to move the definition to a val, and
+  * often the version too. If the library is used in another module for test only, another val is
+  * required:
+  *
+  *      val alleycatsV = "0.1.0"
+  *      val alleycatsDeps = Seq(libraryDependencies += "org.typelevel" %% "alleycats" % alleycatsV)
+  *      val alleycatsTestDeps = Seq(libraryDependencies += "org.typelevel" %% "alleycats" % alleycatsV % "test")
+  *
+  * Whilst this works fine for individual projects, it's not ideal when a group of loosely coupled want
+  * to share a common set (or sets) of dependencies, that they can also modify locally if required.
+  * In this sense, we need "cascading configuration dependency files" and this is what this plugin also
+  * provides.
+  *
+  * "org.typelevel.depenendcies" provides two Maps, one for library versions the the for individual libraries
+  * with their organisation, name and version. Being standard scala Maps, other dependency Maps can be added
+  * with new or updated dependencies. The same applies for scala plugins. To use, we create the three Maps and
+  * add to a combined container and then add the required dependencies to a module: eg
+  *
+  *     val vers = typelevel.versions ++ catalysts.versions + ("discipline" -> "0.3")
+  *     val libs = typelevel.libraries ++ catalysts.libraries
+  *     val addins = typelevel.scalacPlugins ++ catalysts.scalacPlugins
+  *     val vAll = Versions(vers, libs, addins)
+  *     ....
+  *    .settings(addLibs(vAll, "specs2-core","specs2-scalacheck" ):_*)
+  *    .settings(addTestLibs(vAll, "scalatest" ):_*)
+  *
+  */
+trait CatalystsBase {
+
+  import CatalystsKeys._
+
+  type VersionsType     = Map[String, String]
+  type LibrariesType    = Map[String, (String, String, String)]
+  type ScalacPluginType = Map[String, (String, String, String, CrossVersion)]
+
+  /** Container for the version, library and scala plugin Maps.*/
+  case class Versions(vers: VersionsType, libs: LibrariesType, plugs: ScalacPluginType) {
+    def vLibs  = (vers, libs)
+    def vPlugs = (vers, plugs)
+  }
+
+  // Licences
+  /** Apache 2.0 Licence.*/
+  val apache = ("Apache License", url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
+
+  /** MIT Licence.*/
+  val mit = ("MIT", url("http://opensource.org/licenses/MIT"))
+
+  /** Github settings and related settings usually found in a Github README.*/
+  case class GitHubSettings(org: String, proj: String, publishOrg: String, license: (String, URL)) {
+    def home         = s"https://github.com/$org/$proj"
+    def repo         = s"git@github.com:$org/$proj.git"
+    def api          = s"https://$org.github.io/$proj/api/"
+    def organisation = s"com.github.$org"
+    override def toString =
+      s"GitHubSettings:home = $home\nGitHubSettings:repo = $repo\nGitHubSettings:api = $api\nGitHubSettings:organisation = $organisation"
+  }
+
+  /** The name and github user id */
+  //From https://github.com/typelevel/sbt-typelevel/blob/master/src/main/scala/Developer.scala
+  case class Dev(name: String, id: String) {
+    def pomExtra: xml.NodeSeq =
+      <developer>
+        <id>{ id }</id>
+        <name>{ name }</name>
+        <url>http://github.com/{ id }</url>
+          </developer>
+  }
+
+  /** Using the supplied Versions map, adds the list of libraries to a module.*/
+  def addLibs(versions: Versions, libs: String*) =
+    libs.flatMap(
+      s =>
+        Seq(
+          libraryDependencies +=
+            versions.libs(s)._2 %%% versions.libs(s)._3 % versions.vers(versions.libs(s)._1)))
+
+  /** Using the supplied Versions map, adds the list of libraries to a module as a compile dependency.*/
+  def addCompileLibs(versions: Versions, libs: String*) =
+    addLibsScoped(versions, "compile", libs: _*)
+
+  /** Using the supplied Versions map, adds the list of libraries to a module as a test dependency.*/
+  def addTestLibs(versions: Versions, libs: String*) = addLibsScoped(versions, "test", libs: _*)
+
+  /** Using versions map, adds the list of libraries to a module using the given dependency.*/
+  def addLibsScoped(versions: Versions, scope: String, libs: String*) =
+    libs.flatMap(s =>
+      Seq(libraryDependencies +=
+        versions.libs(s)._2 %%% versions.libs(s)._3 % versions.vers(versions.libs(s)._1) % scope))
+
+  /** Using the supplied Versions map, adds the list of compiler plugins to a module.*/
+  def addCompilerPlugins(v: Versions, plugins: String*) =
+    plugins.flatMap(
+      s =>
+        Seq(
+          libraryDependencies += compilerPlugin(
+            v.plugs(s)._2 %% v.plugs(s)._3 % v.vers(v.plugs(s)._1) cross v.plugs(s)._4)))
+
+  // Common and shared setting
+  /** Settings to make the module not published*/
+  lazy val noPublishSettings = Seq(
+    publish := (),
+    publishLocal := (),
+    publishArtifact := false
+  )
+
+  /**
+    * Default settings for the root module.
+    *
+    * Sets the root module name to root and sets the module not to be published
+    */
+  lazy val rootSettings = noPublishSettings ++ Seq(
+      moduleName := "root"
+    )
+
+  /** Adds the settings required to add scala versioned shared directory.
+    *
+    * In a scala.js shared project, the shared sources are by default in a
+    * the directory "shared/src/main/scala". By adding these settings, the build will also
+    * look in the directories that match the scala version:
+    *
+    *      "shared/src/main/scala-2.10"
+    *      "shared/src/main/scala-2.11"
+    */
+  lazy val crossVersionSharedSources: Seq[Setting[_]] =
+    Seq(Compile, Test).map { sc =>
+      (unmanagedSourceDirectories in sc) ++= {
+        (unmanagedSourceDirectories in sc).value.map { dir: File =>
+          new File(dir.getPath + "-" + scalaBinaryVersion.value)
+        }
+      }
+    }
+
+  /** Using the supplied Versions map, adds the dependencies for scala macros.*/
+  def scalaMacroDependencies(v: Versions): Seq[Setting[_]] = {
+    val version = v.vers("paradise")
+    Seq(
+      libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided",
+      libraryDependencies += "org.scala-lang" % "scala-reflect"  % scalaVersion.value % "provided",
+      libraryDependencies ++= {
+        CrossVersion.partialVersion(scalaVersion.value) match {
+          // if scala 2.11+ is used, quasiquotes are merged into scala-reflect
+          case Some((2, scalaMajor)) if scalaMajor >= 11 => Seq()
+          // in Scala 2.10, quasiquotes are provided by macro paradise
+          case Some((2, 10)) =>
+            Seq(
+              compilerPlugin("org.scalamacros" %% "paradise" % version cross CrossVersion.full),
+              "org.scalamacros" %% "quasiquotes" % version cross CrossVersion.binary
+            )
+        }
+      }
+    )
+  }
+
+  /** Common scalac options useful to most (if not all) projects.*/
+  lazy val scalacCommonOptions = Seq(
+    "-deprecation",
+    "-encoding",
+    "UTF-8",
+    "-feature",
+    "-unchecked",
+    "-Xlint"
+  )
+
+  /** Scalac options for additional language options.*/
+  lazy val scalacLanguageOptions = Seq(
+    "-language:existentials",
+    "-language:higherKinds",
+    "-language:implicitConversions",
+    "-language:experimental.macros"
+  )
+
+  /** Scalac strict compilation options.*/
+  lazy val scalacStrictOptions = Seq(
+    "-Xfatal-warnings",
+    "-Yinline-warnings",
+    "-Yno-adapted-args",
+    "-Ywarn-dead-code",
+    "-Ywarn-numeric-widen",
+    "-Ywarn-value-discard",
+    "-Xfuture"
+  )
+
+  /** Combines all scalac options.*/
+  lazy val scalacAllOptions = scalacCommonOptions ++ scalacLanguageOptions ++ scalacStrictOptions
+
+  /**
+    * Settings common to all projects.
+    *
+    * Adds Sonatype release repository and "withCachedResolution" to the update options
+    */
+  lazy val sharedCommonSettings = Seq(
+    resolvers ++= Seq(
+      Resolver.sonatypeRepo("releases")
+    ),
+    updateOptions := updateOptions.value.withCachedResolution(true),
+    travisBuild := scala.sys.env.get("TRAVIS").isDefined
+  )
+
+  /**
+    * Scala JS settings shared by many projects.
+    *
+    * Forces the use of node.js in tests and batchmode under travis
+    */
+  lazy val sharedJsSettings = Seq(
+    scalaJSStage in Global := FastOptStage,
+    parallelExecution := false,
+    requiresDOM := false,
+    jsEnv := NodeJSEnv().value,
+    // batch mode decreases the amount of memory needed to compile scala.js code
+    scalaJSOptimizerOptions := scalaJSOptimizerOptions.value.withBatchMode(travisBuild.value)
+  )
+
+  /**
+    * Scala JVM settings shared by many projects.
+    *
+    * Currently empty.
+    */
+  lazy val sharedJvmSettings = Seq()
+
+  /**
+    * Build settings common to all projects.
+    *
+    * Uses the github settings and versions map to set the organisation,
+    * scala version and cross versions
+    */
+  def sharedBuildSettings(gh: GitHubSettings, v: Versions) = Seq(
+    organization := gh.publishOrg,
+    scalaVersion := v.vers("scalac"),
+    crossScalaVersions := Seq(v.vers("scalac_2.10"), scalaVersion.value)
+  )
+
+  /**
+    * Publish settings common to all projects.
+    *
+    * Uses the github settings and list of developers to set all publish settings
+    * required to publish signed artifacts to Sonatype OSS repository
+    */
+  def sharedPublishSettings(gh: GitHubSettings, devs: Seq[Dev]): Seq[Setting[_]] = Seq(
+    homepage := Some(url(gh.home)),
+    licenses += gh.license,
+    scmInfo := Some(ScmInfo(url(gh.home), "scm:git:" + gh.repo)),
+    apiURL := Some(url(gh.api)),
+    releaseCrossBuild := true,
+    releasePublishArtifactsAction := PgpKeys.publishSigned.value,
+    publishMavenStyle := true,
+    publishArtifact in Test := false,
+    pomIncludeRepository := Function.const(false),
+    publishTo := {
+      val nexus = "https://oss.sonatype.org/"
+      if (isSnapshot.value)
+        Some("Snapshots" at nexus + "content/repositories/snapshots")
+      else
+        Some("Releases" at nexus + "service/local/staging/deploy/maven2")
+    },
+    autoAPIMappings := true,
+    pomExtra := <developers> { devs.map(_.pomExtra) } </developers>
+  )
+
+  /**
+    * Release settings common to all projects.
+    *
+    * Adds a Sonatype release step to the default release steps
+    */
+  lazy val sharedReleaseProcess = Seq(
+    releaseProcess := Seq[ReleaseStep](
+      checkSnapshotDependencies,
+      inquireVersions,
+      runClean,
+      runTest,
+      setReleaseVersion,
+      commitReleaseVersion,
+      tagRelease,
+      publishArtifacts,
+      setNextVersion,
+      commitNextVersion,
+      ReleaseStep(action = Command.process("sonatypeReleaseAll", _)),
+      pushChanges)
+  )
+
+  /** Common coverage settings, with minimum coverage defaulting to 80.*/
+  def sharedScoverageSettings(min: Int = 80) = Seq(
+    ScoverageKeys.coverageMinimum := min,
+    ScoverageKeys.coverageFailOnMinimum := false,
+    ScoverageKeys.coverageHighlighting := scalaBinaryVersion.value != "2.10"
+    // ScoverageKeys.coverageExcludedPackages := "catalysts\\.bench\\..*"
+  )
+
+  /** Common unidoc settings, adding the "-Ymacro-no-expand" scalac option.*/
+  lazy val unidocCommonSettings = Seq(
+    scalacOptions in (ScalaUnidoc, unidoc) += "-Ymacro-no-expand"
+  )
+
+  /** Add the "unused import" warning to scala 2.11+, but not for the console.*/
+  lazy val warnUnusedImport = Seq(
+    scalacOptions ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, 10)) =>
+          Seq()
+        case Some((2, n)) if n >= 11 =>
+          Seq("-Ywarn-unused-import")
+      }
+    },
+    //use this when activator moved to 13.9
+    // scalacOptions in (Compile, console) -= "-Ywarn-unused-import",
+    scalacOptions in (Compile, console) ~= { _.filterNot("-Ywarn-unused-import" == _) },
+    scalacOptions in (Test, console) := { scalacOptions in (Compile, console) }.value
+  )
+
+  /** Adds the credential settings required for sonatype releases.*/
+  lazy val credentialSettings = Seq(
+    // For Travis CI - see http://www.cakesolutions.net/teamblogs/publishing-artefacts-to-oss-sonatype-nexus-using-sbt-and-travis-ci
+    credentials ++= (for {
+      username <- Option(System.getenv().get("SONATYPE_USERNAME"))
+      password <- Option(System.getenv().get("SONATYPE_PASSWORD"))
+    } yield
+      Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", username, password)).toSeq
+  )
+
+  // Builder methods
+
+  /**
+    * Creates a module definition based on a Scala.js CrossProject
+    *
+    * The standard Scala.js CrossProject contains the real JVM and JS project
+    * and can be used as a dependency of another CrossProject. But it not an
+    * sbt Project, and cannot be used as one.
+    *
+    * So we introduce the concept of a Module, that is essentially a CrossProject
+    * with the difference that the variable name is the directory name with the
+    * suffix "M". This allows us to create a real project based on the directory name
+    * that is an aggregate project for the underlying JS and JVM projects.
+    *
+    * Usage;
+    *
+    * In build.sbt, create two helper methods:
+    *
+    *   lazy val module = mkModuleFactory(gh.proj, mkConfig(rootSettings, commonJvmSettings, commonJsSettings))
+    *   lazy val prj = mkPrjFactory(rootSettings)
+    *
+    * For each sub-project (here core is used as an example)
+    *
+    *   lazy val core    = prj(coreM)
+    *   lazy val coreJVM = coreM.jvm
+    *   lazy val coreJS  = coreM.js
+    *   lazy val coreM   = module("core",CrossType.Pure)
+    *     .dependsOn(testkitM)
+    *     .settings(addTestLibs(vlibs, "scalatest"):_*)
+    */
+  def mkModule(proj: String,
+               projConfig: CrossProject ⇒ CrossProject,
+               id: String,
+               crossType: CrossType = CrossType.Pure): CrossProject = {
+
+    val cpId = id.stripSuffix("M")
+
+    CrossProject(cpId, new File(cpId), crossType)
+      .settings(moduleName := s"$proj-$id")
+      .configureCross(projConfig)
+  }
+
+  /**
+    * Helper method for mkModule so that the main project name and configuration need not ne repeated for each module
+    */
+  def mkModuleFactory(proj: String, projConfig: CrossProject ⇒ CrossProject) =
+    (id: String, crossType: CrossType) => mkModule(proj, projConfig, id, crossType)
+
+  /**
+    * Makes a modules aggregate project
+    */
+  def mkPrj(projSettings: Seq[sbt.Setting[_]], c: CrossProject): Project = {
+    val name                      = c.jvm.id.stripSuffix("JVM")
+    val pr: Seq[ProjectReference] = Seq(c.jvm.project, c.js.project)
+
+    Project(id = name, base = new File(s"$name/.prj"))
+      .settings(noPublishSettings: _*)
+      .settings(projSettings)
+      .dependsOn(c.jvm, c.js)
+      .aggregate(c.jvm, c.js)
+  }
+
+  /**
+    * Helper method for mkPrj so that the main project settings need not be repeated for each module
+    */
+  def mkPrjFactory(projSettings: Seq[sbt.Setting[_]]) = (c: CrossProject) => mkPrj(projSettings, c)
+
+  // Config builders
+
+  /**
+    * Helper method that sets the default project(i.e. platform independent), JS and JVM settings.
+    */
+  def mkConfig(projSettings: Seq[sbt.Setting[_]],
+               jvmSettings: Seq[sbt.Setting[_]],
+               jsSettings: Seq[sbt.Setting[_]]): CrossProject ⇒ CrossProject =
+    _.settings(projSettings: _*).jsSettings(jsSettings: _*).jvmSettings(jvmSettings: _*)
+
+  /**
+    * Helper method that sets the root project's settings
+    *
+    * In addition to setting the root settings, also adds the rootJVM settings to be used in
+    * in root console.
+    */
+  def mkRootConfig(projSettings: Seq[sbt.Setting[_]], projJVM: Project): Project ⇒ Project =
+    _.in(file("."))
+      .settings(rootSettings)
+      .settings(projSettings)
+      .settings(console := { console in (projJVM, Compile) }.value)
+
+  /**
+    * Creates the rootJVM project.
+    *
+    * Creates the rootJVM project in ".rootJVM" with the default settings and
+    * JVM specific default settings.
+    */
+  def mkRootJvmConfig(s: String,
+                      projSettings: Seq[sbt.Setting[_]],
+                      jvmSettings: Seq[sbt.Setting[_]]): Project ⇒ Project =
+    _.settings(moduleName := s)
+      .settings(projSettings)
+      .settings(jvmSettings)
+      .in(file("." + s + "JVM"))
+
+  /**
+    * Creates the rootJS project.
+    *
+    * Creates the rootJS project in ".rootJS" with the default settings and
+    * JS specific default settings.
+    */
+  def mkRootJsConfig(s: String,
+                     projSettings: Seq[sbt.Setting[_]],
+                     jsSettings: Seq[sbt.Setting[_]]): Project ⇒ Project =
+    _.settings(moduleName := s)
+      .settings(projSettings)
+      .settings(jsSettings)
+      .in(file("." + s + "JS"))
+      .enablePlugins(ScalaJSPlugin)
+
+  /**
+    * Creates a configuration for a document project for scaladoc and a GitHubPages site
+    *
+    * Creates the basic settings for a document project based on the supplied GitHub settings,
+    * project and JVM settings. The documentation is created for the supplied list of projects.
+    */
+  def mkDocConfig(gh: GitHubSettings,
+                  projSettings: Seq[sbt.Setting[_]],
+                  jvmSettings: Seq[sbt.Setting[_]],
+                  deps: Project*): Project ⇒ Project =
+    _.settings(projSettings)
+      .settings(moduleName := gh.proj + "-docs")
+      .settings(noPublishSettings)
+      .settings(unidocSettings)
+      .settings(tutSettings)
+      .settings(ghpages.settings)
+      .settings(jvmSettings)
+      .dependsOn(deps.map(ClasspathDependency(_, Some("compile;test->test"))): _*)
+      .settings(
+        organization := gh.organisation,
+        autoAPIMappings := true,
+        unidocProjectFilter in (ScalaUnidoc, unidoc) := inProjects(deps.map(_.project): _*),
+        docsMappingsAPIDir := "api",
+        addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), docsMappingsAPIDir),
+        ghpagesNoJekyll := false,
+        tutScalacOptions ~= (_.filterNot(Set("-Ywarn-unused-import", "-Ywarn-dead-code"))),
+        scalacOptions in (ScalaUnidoc, unidoc) ++= Seq(
+          "-doc-source-url",
+          scmInfo.value.get.browseUrl + "/tree/master€{FILE_PATH}.scala",
+          "-sourcepath",
+          baseDirectory.in(LocalRootProject).value.getAbsolutePath,
+          "-diagrams"
+        ),
+        git.remoteRepo := gh.repo,
+        includeFilter in makeSite := "*.html" | "*.css" | "*.png" | "*.jpg" | "*.gif" | "*.js" | "*.swf" | "*.yml" | "*.md")
+}
+
+object CatalystsKeys extends BaseCatalystsKeys
+
+class BaseCatalystsKeys {
+
+  lazy val travisBuild = settingKey[Boolean]("Build by TravisCI instead of local dev environment")
+
+  lazy val docsMappingsAPIDir =
+    settingKey[String]("Name of subdirectory in site target directory for api docs")
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.5-SNAPSHOT"
+version in ThisBuild := "0.1.0-SNAPSHOT"


### PR DESCRIPTION
This PR makes this plugin independent from the [sbt-catalyst plugin](https://github.com/typelevel/sbt-catalysts). Basically it becomes like a fork extended with new capabilities.

* Upgrades library versions
* Upgrades sbt to 0.13.13
* Removes scalafmt due to a sbt bug
* Bumps version to `0.1.0`

Please, @raulraja could you review? Thanks!